### PR TITLE
Fix: bazel version to 4.0.0 and com_grail_bazel_toolchain dependency to upstream grailbio/bazel-toolchain instead of mjbots/bazel-toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,4 @@
 build --incompatible_enable_cc_toolchain_resolution
-build --experimental_allow_incremental_repository_updates
 
 build --features=c++20
 build --features=-c++17

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,8 @@
 
 workspace(name = "com_github_mjbots_moteus")
 
-BAZEL_VERSION = "3.4.1"
-BAZEL_VERSION_SHA = "1a64c807716e10c872f1618852d95f4893d81667fe6e691ef696489103c9b460"
+BAZEL_VERSION = "4.0.0"
+BAZEL_VERSION_SHA = "7bee349a626281fc8b8d04a7a0b0358492712377400ab12533aeb39c2eb2b901"
 
 load("//tools/workspace:default.bzl", "add_default_repositories")
 

--- a/tools/workspace/bazel_toolchain/repository.bzl
+++ b/tools/workspace/bazel_toolchain/repository.bzl
@@ -19,7 +19,7 @@ load("//tools/workspace:github_archive.bzl", "github_archive")
 def bazel_toolchain_repository():
     github_archive(
         name = "com_grail_bazel_toolchain",
-        repo = "mjbots/bazel-toolchain",
-        commit = "9b0bae6a79392920698b9778e334ce2354b425a5",
-        sha256 = "36420a9fc39fb9462f06c0da386bb987a191cc0e388909fe4873e2a3c758c2be",
+        repo = "grailbio/bazel-toolchain",
+        commit = "056aeaa01900f5050a9fed9b11e2d365a684831a",
+        sha256 = "d319a1155a3a5079954868d814d316d77b18cd89b8cb3554ad06d64c12b8bef1",
     )


### PR DESCRIPTION
Updating bazel version to 4.0.0 and com_grail_bazel_toolchain dependency to upstream grailbio/bazel-toolchain instead of mjbots/bazel-toolchain was necessary for me to be able to build the Moteus firmware on Ubuntu / Pop!_OS 22.04 Jammy.

From https://github.com/mjbots/bazel-toolchain
> This branch is [100 commits behind](https://github.com/mjbots/bazel-toolchain/compare/master...grailbio:bazel-toolchain:master) grailbio:master.

@aburt2 Would you please mind trying if you can build this branch?